### PR TITLE
Revert "fixed problem for using pca instead of princomp in new matlab…

### DIFF
--- a/wc_get_features.m
+++ b/wc_get_features.m
@@ -43,13 +43,13 @@ end
 
 %% PCA
 if strfind(feature,'pca')
+    numdim = 10;
     matlabversion=datevec(version('-date'));
     if matlabversion(1)>=2014
         [~,S] = pca(spikes(:,ind1),'Economy',false); 
     else
         [~,S] = princomp(spikes(:,ind1)); 
     end
-    numdim = min(10,size(S,2));
     fn = cell(1,numdim);
     for i=1:numdim
         fn{i}=sprintf('PCA,%d',i);


### PR DESCRIPTION
… versions"

This reverts commit b917fc81862e78d70fb6d7821419b691279492fe to keep feature dimensions as after using princomp